### PR TITLE
Add Deserialize to PublicKey

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,13 @@ edition = "2021"
 
 [dependencies]
 heapless-bytes = "0.3.0"
-serde = "1.0"
+serde_repr = "0.1.10"
 serde_derive = "1.0"
-serde_repr = "0.1.6"
+
+[dependencies.serde]
+version = "1.0"
+default-features = false
+features = ["derive", "alloc"]
+
+[dev-dependencies]
+serde_test = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosey"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Nicolas Stalder <n@stalder.io>"]
 license = "Apache-2.0 OR MIT"
 description = "Data types and serde for public COSE_Keys"
@@ -8,13 +8,10 @@ categories = ["embedded", "encoding", "no-std"]
 keywords = ["cose", "cbor", "rust", "no-std"]
 repository = "https://github.com/ycrypto/cosey"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 heapless-bytes = "0.3.0"
-serde_repr = "0.1"
-
-[dependencies.serde]
-version = "1.0"
-default-features = false
-features = ["derive"]
+serde = "1.0"
+serde_derive = "1.0"
+serde_repr = "0.1.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,8 +99,6 @@ enum Crv {
     // Ed448 = 7,
 }
 
-// `Deserialize` can't be derived on untagged enum,
-// would need to "sniff" for correct (Kty, Alg, Crv) triple
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum PublicKey {
@@ -500,5 +498,109 @@ impl<'de> serde::Deserialize<'de> for TotpPublicKey {
             }
         }
         deserializer.deserialize_map(IndexedVisitor {})
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use heapless_bytes::Bytes;
+    use serde_test::{assert_tokens, Token};
+
+    use super::{
+        EcdhEsHkdf256PublicKey, Ed25519PublicKey, Label, P256PublicKey, PublicKey,
+        PublicKeyConstants, TotpPublicKey,
+    };
+
+    #[test]
+    fn deserialize_publickey_p256key() {
+        let x = &[1; 32];
+        let y = &[2; 32];
+        let expected = PublicKey::P256Key(P256PublicKey {
+            x: Bytes::from_slice(x).unwrap(),
+            y: Bytes::from_slice(y).unwrap(),
+        });
+        assert_tokens(
+            &expected,
+            &[
+                Token::Map { len: Some(5) },
+                Token::I8(Label::Kty as i8),
+                Token::I8(P256PublicKey::KTY as i8),
+                Token::I8(Label::Alg as i8),
+                Token::I8(P256PublicKey::ALG as i8),
+                Token::I8(Label::Crv as i8),
+                Token::I8(P256PublicKey::CRV as i8),
+                Token::I8(Label::X as i8),
+                Token::Bytes(x),
+                Token::I8(Label::Y as i8),
+                Token::Bytes(y),
+                Token::MapEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn deserialize_publickey_ecdheshkdf256() {
+        let x = &[1; 32];
+        let y = &[2; 32];
+        let expected = PublicKey::EcdhEsHkdf256Key(EcdhEsHkdf256PublicKey {
+            x: Bytes::from_slice(x).unwrap(),
+            y: Bytes::from_slice(y).unwrap(),
+        });
+        assert_tokens(
+            &expected,
+            &[
+                Token::Map { len: Some(5) },
+                Token::I8(Label::Kty as i8),
+                Token::I8(EcdhEsHkdf256PublicKey::KTY as i8),
+                Token::I8(Label::Alg as i8),
+                Token::I8(EcdhEsHkdf256PublicKey::ALG as i8),
+                Token::I8(Label::Crv as i8),
+                Token::I8(EcdhEsHkdf256PublicKey::CRV as i8),
+                Token::I8(Label::X as i8),
+                Token::Bytes(x),
+                Token::I8(Label::Y as i8),
+                Token::Bytes(y),
+                Token::MapEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn deserialize_publickey_ed25519key() {
+        let x = &[1; 32];
+        let expected = PublicKey::Ed25519Key(Ed25519PublicKey {
+            x: Bytes::from_slice(x).unwrap(),
+        });
+        assert_tokens(
+            &expected,
+            &[
+                Token::Map { len: Some(4) },
+                Token::I8(Label::Kty as i8),
+                Token::I8(Ed25519PublicKey::KTY as i8),
+                Token::I8(Label::Alg as i8),
+                Token::I8(Ed25519PublicKey::ALG as i8),
+                Token::I8(Label::Crv as i8),
+                Token::I8(Ed25519PublicKey::CRV as i8),
+                Token::I8(Label::X as i8),
+                Token::Bytes(x),
+                Token::MapEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn deserialize_publickey_totpkey() {
+        let expected = PublicKey::TotpKey(TotpPublicKey {});
+        assert_tokens(
+            &expected,
+            &[
+                Token::Map { len: Some(2) },
+                Token::I8(Label::Kty as i8),
+                Token::I8(TotpPublicKey::KTY as i8),
+                Token::I8(Label::Alg as i8),
+                Token::I8(TotpPublicKey::ALG as i8),
+                Token::MapEnd,
+            ],
+        );
     }
 }


### PR DESCRIPTION
Hey @nickray, thanks for your work on cosey! 

I'm using cosey in my project, [xdg-credentials-portal](https://github.com/AlfioEmanueleFresta/xdg-credentials-portal).  I've made a change locally which I'd like to merge upstream. 

I needed a Deserialize implementation of PublicKey ([used here for Ctap2](https://github.com/AlfioEmanueleFresta/xdg-credentials-portal/blob/master/libwebauthn/src/proto/ctap2/model.rs#L94)). I added the Deserialize trait to the uncovered enum variant, marked the enum as untagged, and added a few tests to verify the enum variants are parsed as expected.

I had to update the serde feature configuration, adding alloc, to ensure untagged deserialization worked.

Tests:

```
$ cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.01s
     Running unittests src/lib.rs (target/debug/deps/cosey-8f4d10046bb30e5c)

running 4 tests
test tests::deserialize_publickey_ecdheshkdf256 ... ok
test tests::deserialize_publickey_ed25519key ... ok
test tests::deserialize_publickey_p256key ... ok
test tests::deserialize_publickey_totpkey ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests cosey

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```