### PR TITLE
Make COSE deserialization more robust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,8 @@ serde_repr = "0.1"
 version = "1.0"
 default-features = false
 features = ["derive"]
+
+[dev-dependencies]
+cbor-smol = "0.4"
+hex = "0.4.3"
+quickcheck = "1.0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,11 +44,17 @@
 */
 
 pub use heapless_bytes::Bytes;
-use serde::Serialize;
+
+use core::fmt::{self, Formatter};
+use serde::{
+    de::{Error, Expected, MapAccess, Unexpected, Visitor},
+    ser::SerializeMap as _,
+    Deserialize, Deserializer, Serialize, Serializer,
+};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[repr(i8)]
-#[derive(Clone, Debug, Eq, PartialEq, Serialize_repr, Deserialize_repr)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize_repr, Deserialize_repr)]
 enum Label {
     Kty = 1,
     Alg = 3,
@@ -58,15 +64,21 @@ enum Label {
 }
 
 #[repr(i8)]
-#[derive(Clone, Debug, Eq, PartialEq, Serialize_repr, Deserialize_repr)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize_repr, Deserialize_repr)]
 enum Kty {
     Okp = 1,
     Ec2 = 2,
     Symmetric = 4,
 }
 
+impl Expected for Kty {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", *self as i8)
+    }
+}
+
 #[repr(i8)]
-#[derive(Clone, Debug, Eq, PartialEq, Serialize_repr, Deserialize_repr)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize_repr, Deserialize_repr)]
 enum Alg {
     Es256 = -7, // ECDSA with SHA-256
     EdDsa = -8,
@@ -86,8 +98,14 @@ enum Alg {
     EcdhEsHkdf256 = -25, // ES = ephemeral-static
 }
 
+impl Expected for Alg {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", *self as i8)
+    }
+}
+
 #[repr(i8)]
-#[derive(Clone, Debug, Eq, PartialEq, Serialize_repr, Deserialize_repr)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize_repr, Deserialize_repr)]
 enum Crv {
     None = 0,
     P256 = 1,
@@ -97,6 +115,12 @@ enum Crv {
     // X448 = 5,
     Ed25519 = 6,
     // Ed448 = 7,
+}
+
+impl Expected for Crv {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", *self as i8)
+    }
 }
 
 // `Deserialize` can't be derived on untagged enum,
@@ -134,13 +158,97 @@ impl From<TotpPublicKey> for PublicKey {
     }
 }
 
+#[derive(Clone, Debug, Default)]
+struct RawPublicKey {
+    kty: Option<Kty>,
+    alg: Option<Alg>,
+    crv: Option<Crv>,
+    x: Option<Bytes<32>>,
+    y: Option<Bytes<32>>,
+}
+
+impl<'de> Deserialize<'de> for RawPublicKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct IndexedVisitor;
+        impl<'de> Visitor<'de> for IndexedVisitor {
+            type Value = RawPublicKey;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> fmt::Result {
+                formatter.write_str("RawPublicKey")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<RawPublicKey, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut public_key = RawPublicKey::default();
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Label::Kty => public_key.kty = Some(map.next_value()?),
+                        Label::Alg => public_key.alg = Some(map.next_value()?),
+                        Label::Crv => public_key.crv = Some(map.next_value()?),
+                        Label::X => public_key.x = Some(map.next_value()?),
+                        Label::Y => public_key.y = Some(map.next_value()?),
+                    }
+                }
+                Ok(public_key)
+            }
+        }
+        deserializer.deserialize_map(IndexedVisitor {})
+    }
+}
+
+impl Serialize for RawPublicKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let is_set = [
+            self.kty.is_some(),
+            self.alg.is_some(),
+            self.crv.is_some(),
+            self.x.is_some(),
+            self.y.is_some(),
+        ];
+        let fields = is_set.iter().copied().map(usize::from).sum();
+        let mut map = serializer.serialize_map(Some(fields))?;
+
+        //  1: kty
+        if let Some(kty) = &self.kty {
+            map.serialize_entry(&(Label::Kty as i8), &(*kty as i8))?;
+        }
+        //  3: alg
+        if let Some(alg) = &self.alg {
+            map.serialize_entry(&(Label::Alg as i8), &(*alg as i8))?;
+        }
+        // -1: crv
+        if let Some(crv) = &self.crv {
+            map.serialize_entry(&(Label::Crv as i8), &(*crv as i8))?;
+        }
+        // -2: x
+        if let Some(x) = &self.x {
+            map.serialize_entry(&(Label::X as i8), x)?;
+        }
+        // -3: y
+        if let Some(y) = &self.y {
+            map.serialize_entry(&(Label::Y as i8), y)?;
+        }
+
+        map.end()
+    }
+}
+
 trait PublicKeyConstants {
     const KTY: Kty;
     const ALG: Alg;
     const CRV: Crv;
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(into = "RawPublicKey")]
 pub struct P256PublicKey {
     pub x: Bytes<32>,
     pub y: Bytes<32>,
@@ -152,7 +260,20 @@ impl PublicKeyConstants for P256PublicKey {
     const CRV: Crv = Crv::P256;
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+impl From<P256PublicKey> for RawPublicKey {
+    fn from(key: P256PublicKey) -> Self {
+        Self {
+            kty: Some(P256PublicKey::KTY),
+            alg: Some(P256PublicKey::ALG),
+            crv: Some(P256PublicKey::CRV),
+            x: Some(key.x),
+            y: Some(key.y),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(into = "RawPublicKey")]
 pub struct EcdhEsHkdf256PublicKey {
     pub x: Bytes<32>,
     pub y: Bytes<32>,
@@ -164,7 +285,20 @@ impl PublicKeyConstants for EcdhEsHkdf256PublicKey {
     const CRV: Crv = Crv::P256;
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+impl From<EcdhEsHkdf256PublicKey> for RawPublicKey {
+    fn from(key: EcdhEsHkdf256PublicKey) -> Self {
+        Self {
+            kty: Some(EcdhEsHkdf256PublicKey::KTY),
+            alg: Some(EcdhEsHkdf256PublicKey::ALG),
+            crv: Some(EcdhEsHkdf256PublicKey::CRV),
+            x: Some(key.x),
+            y: Some(key.y),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(into = "RawPublicKey")]
 pub struct Ed25519PublicKey {
     pub x: Bytes<32>,
 }
@@ -175,7 +309,20 @@ impl PublicKeyConstants for Ed25519PublicKey {
     const CRV: Crv = Crv::Ed25519;
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+impl From<Ed25519PublicKey> for RawPublicKey {
+    fn from(key: Ed25519PublicKey) -> Self {
+        Self {
+            kty: Some(Ed25519PublicKey::KTY),
+            alg: Some(Ed25519PublicKey::ALG),
+            crv: Some(Ed25519PublicKey::CRV),
+            x: Some(key.x),
+            y: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+#[serde(into = "RawPublicKey")]
 pub struct TotpPublicKey {}
 
 impl PublicKeyConstants for TotpPublicKey {
@@ -184,283 +331,94 @@ impl PublicKeyConstants for TotpPublicKey {
     const CRV: Crv = Crv::None;
 }
 
+impl From<TotpPublicKey> for RawPublicKey {
+    fn from(_key: TotpPublicKey) -> Self {
+        Self {
+            kty: Some(TotpPublicKey::KTY),
+            alg: Some(TotpPublicKey::ALG),
+            crv: None,
+            x: None,
+            y: None,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct X25519PublicKey {
     pub pub_key: Bytes<32>,
 }
 
-// impl serde::Serialize for PublicKey {
-//     fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
-//     where
-//         S: serde::Serializer,
-//     {
-//         match self {
-//             PublicKey::P256Key(key) => key.serialize(serializer),
-//             PublicKey::EcdhEsHkdf256Key(key) => key.serialize(serializer),
-//             PublicKey::Ed25519Key(key) => key.serialize(serializer),
-//         }
-//     }
-// }
-
-impl serde::Serialize for TotpPublicKey {
-    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use serde::ser::SerializeMap;
-        // let mut map = serializer.serialize_map(Some(3))?;
-        let mut map = serializer.serialize_map(Some(2))?;
-
-        //  1: kty
-        map.serialize_entry(&(Label::Kty as i8), &(Self::KTY as i8))?;
-        //  3: alg
-        map.serialize_entry(&(Label::Alg as i8), &(Self::ALG as i8))?;
-        // // -1: crv
-        // map.serialize_entry(&(Label::Crv as i8), &(Self::CRV as i8))?;
-
-        map.end()
+fn check_key_constants<K: PublicKeyConstants, E: Error>(
+    kty: Option<Kty>,
+    alg: Option<Alg>,
+    crv: Option<Crv>,
+) -> Result<(), E> {
+    let kty = kty.ok_or_else(|| E::missing_field("kty"))?;
+    if kty != K::KTY {
+        return Err(E::invalid_value(Unexpected::Signed(kty as _), &K::KTY));
     }
+    if let Some(alg) = alg {
+        if alg != K::ALG {
+            return Err(E::invalid_value(Unexpected::Signed(alg as _), &K::ALG));
+        }
+    }
+    if K::CRV != Crv::None {
+        let crv = crv.ok_or_else(|| E::missing_field("crv"))?;
+        if crv != K::CRV {
+            return Err(E::invalid_value(Unexpected::Signed(crv as _), &K::CRV));
+        }
+    }
+    Ok(())
 }
 
-impl serde::Serialize for P256PublicKey {
-    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use serde::ser::SerializeMap;
-        let mut map = serializer.serialize_map(Some(5))?;
-
-        //  1: kty
-        map.serialize_entry(&(Label::Kty as i8), &(Self::KTY as i8))?;
-        //  3: alg
-        map.serialize_entry(&(Label::Alg as i8), &(Self::ALG as i8))?;
-        // -1: crv
-        map.serialize_entry(&(Label::Crv as i8), &(Self::CRV as i8))?;
-        // -2: x
-        map.serialize_entry(&(Label::X as i8), &self.x)?;
-        // -3: y
-        map.serialize_entry(&(Label::Y as i8), &self.y)?;
-
-        map.end()
-    }
-}
-
-impl serde::Serialize for EcdhEsHkdf256PublicKey {
-    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use serde::ser::SerializeMap;
-        let mut map = serializer.serialize_map(Some(5))?;
-
-        //  1: kty
-        map.serialize_entry(&(Label::Kty as i8), &(Self::KTY as i8))?;
-        //  3: alg
-        map.serialize_entry(&(Label::Alg as i8), &(Self::ALG as i8))?;
-        // -1: crv
-        map.serialize_entry(&(Label::Crv as i8), &(Self::CRV as i8))?;
-        // -2: x
-        map.serialize_entry(&(Label::X as i8), &self.x)?;
-        // -3: y
-        map.serialize_entry(&(Label::Y as i8), &self.y)?;
-
-        map.end()
-    }
-}
-
-impl serde::Serialize for Ed25519PublicKey {
-    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use serde::ser::SerializeMap;
-        let mut map = serializer.serialize_map(Some(4))?;
-
-        //  1: kty
-        map.serialize_entry(&(Label::Kty as i8), &(Self::KTY as i8))?;
-        //  3: alg
-        map.serialize_entry(&(Label::Alg as i8), &(Self::ALG as i8))?;
-        // -1: crv
-        map.serialize_entry(&(Label::Crv as i8), &(Self::CRV as i8))?;
-        // -2: pub_key
-        map.serialize_entry(&(Label::X as i8), &self.x)?;
-
-        map.end()
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for P256PublicKey {
+impl<'de> Deserialize<'de> for P256PublicKey {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: Deserializer<'de>,
     {
-        struct IndexedVisitor;
-        impl<'de> serde::de::Visitor<'de> for IndexedVisitor {
-            type Value = P256PublicKey;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
-                formatter.write_str("P256PublicKey")
-            }
-
-            fn visit_map<V>(self, mut map: V) -> Result<P256PublicKey, V::Error>
-            where
-                V: serde::de::MapAccess<'de>,
-            {
-                // implies kty-specific params
-                match (map.next_key()?, map.next_value()?) {
-                    (Some(Label::Kty), Some(P256PublicKey::KTY)) => {}
-                    _ => {
-                        return Err(serde::de::Error::missing_field("kty"));
-                    }
-                }
-
-                // restricts key usage - check!
-                match (map.next_key()?, map.next_value()?) {
-                    (Some(Label::Alg), Some(P256PublicKey::ALG)) => {}
-                    _ => {
-                        return Err(serde::de::Error::missing_field("alg"));
-                    }
-                }
-
-                match (map.next_key()?, map.next_value()?) {
-                    (Some(Label::Crv), Some(P256PublicKey::CRV)) => {}
-                    _ => {
-                        return Err(serde::de::Error::missing_field("crv"));
-                    }
-                }
-
-                let x = match (map.next_key()?, map.next_value()?) {
-                    (Some(Label::X), Some(bytes)) => bytes,
-                    _ => {
-                        return Err(serde::de::Error::missing_field("x"));
-                    }
-                };
-
-                let y = match (map.next_key()?, map.next_value()?) {
-                    (Some(Label::Y), Some(bytes)) => bytes,
-                    _ => {
-                        return Err(serde::de::Error::missing_field("y"));
-                    }
-                };
-
-                Ok(P256PublicKey { x, y })
-            }
-        }
-        deserializer.deserialize_map(IndexedVisitor {})
+        let RawPublicKey {
+            kty,
+            alg,
+            crv,
+            x,
+            y,
+        } = RawPublicKey::deserialize(deserializer)?;
+        check_key_constants::<P256PublicKey, D::Error>(kty, alg, crv)?;
+        let x = x.ok_or_else(|| D::Error::missing_field("x"))?;
+        let y = y.ok_or_else(|| D::Error::missing_field("y"))?;
+        Ok(Self { x, y })
     }
 }
 
-impl<'de> serde::Deserialize<'de> for EcdhEsHkdf256PublicKey {
+impl<'de> Deserialize<'de> for EcdhEsHkdf256PublicKey {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: Deserializer<'de>,
     {
-        struct IndexedVisitor;
-        impl<'de> serde::de::Visitor<'de> for IndexedVisitor {
-            type Value = EcdhEsHkdf256PublicKey;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
-                formatter.write_str("EcdhEsHkdf256PublicKey")
-            }
-
-            fn visit_map<V>(self, mut map: V) -> Result<EcdhEsHkdf256PublicKey, V::Error>
-            where
-                V: serde::de::MapAccess<'de>,
-            {
-                // implies kty-specific params
-                match (map.next_key()?, map.next_value()?) {
-                    (Some(Label::Kty), Some(EcdhEsHkdf256PublicKey::KTY)) => {}
-                    _ => {
-                        return Err(serde::de::Error::missing_field("kty"));
-                    }
-                }
-
-                // restricts key usage - check!
-                match (map.next_key()?, map.next_value()?) {
-                    (Some(Label::Alg), Some(EcdhEsHkdf256PublicKey::ALG)) => {}
-                    _ => {
-                        return Err(serde::de::Error::missing_field("alg"));
-                    }
-                }
-
-                match (map.next_key()?, map.next_value()?) {
-                    (Some(Label::Crv), Some(EcdhEsHkdf256PublicKey::CRV)) => {}
-                    _ => {
-                        return Err(serde::de::Error::missing_field("crv"));
-                    }
-                }
-
-                let x = match (map.next_key()?, map.next_value()?) {
-                    (Some(Label::X), Some(bytes)) => bytes,
-                    _ => {
-                        return Err(serde::de::Error::missing_field("x"));
-                    }
-                };
-
-                let y = match (map.next_key()?, map.next_value()?) {
-                    (Some(Label::Y), Some(bytes)) => bytes,
-                    _ => {
-                        return Err(serde::de::Error::missing_field("y"));
-                    }
-                };
-
-                Ok(EcdhEsHkdf256PublicKey { x, y })
-            }
-        }
-        deserializer.deserialize_map(IndexedVisitor {})
+        let RawPublicKey {
+            kty,
+            alg,
+            crv,
+            x,
+            y,
+        } = RawPublicKey::deserialize(deserializer)?;
+        check_key_constants::<EcdhEsHkdf256PublicKey, D::Error>(kty, alg, crv)?;
+        let x = x.ok_or_else(|| D::Error::missing_field("x"))?;
+        let y = y.ok_or_else(|| D::Error::missing_field("y"))?;
+        Ok(Self { x, y })
     }
 }
 
-impl<'de> serde::Deserialize<'de> for Ed25519PublicKey {
+impl<'de> Deserialize<'de> for Ed25519PublicKey {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: Deserializer<'de>,
     {
-        struct IndexedVisitor;
-        impl<'de> serde::de::Visitor<'de> for IndexedVisitor {
-            type Value = Ed25519PublicKey;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
-                formatter.write_str("Ed25519PublicKey")
-            }
-
-            fn visit_map<V>(self, mut map: V) -> Result<Ed25519PublicKey, V::Error>
-            where
-                V: serde::de::MapAccess<'de>,
-            {
-                // implies kty-specific params
-                match (map.next_key()?, map.next_value()?) {
-                    (Some(Label::Kty), Some(Ed25519PublicKey::KTY)) => {}
-                    _ => {
-                        return Err(serde::de::Error::missing_field("kty"));
-                    }
-                }
-
-                // restricts key usage - check!
-                match (map.next_key()?, map.next_value()?) {
-                    (Some(Label::Alg), Some(Ed25519PublicKey::ALG)) => {}
-                    _ => {
-                        return Err(serde::de::Error::missing_field("alg"));
-                    }
-                }
-
-                match (map.next_key()?, map.next_value()?) {
-                    (Some(Label::Crv), Some(Ed25519PublicKey::CRV)) => {}
-                    _ => {
-                        return Err(serde::de::Error::missing_field("crv"));
-                    }
-                }
-
-                let x = match (map.next_key()?, map.next_value()?) {
-                    (Some(Label::X), Some(bytes)) => bytes,
-                    _ => {
-                        return Err(serde::de::Error::missing_field("x"));
-                    }
-                };
-
-                Ok(Ed25519PublicKey { x })
-            }
-        }
-        deserializer.deserialize_map(IndexedVisitor {})
+        let RawPublicKey {
+            kty, alg, crv, x, ..
+        } = RawPublicKey::deserialize(deserializer)?;
+        check_key_constants::<Ed25519PublicKey, D::Error>(kty, alg, crv)?;
+        let x = x.ok_or_else(|| D::Error::missing_field("x"))?;
+        Ok(Self { x })
     }
 }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,88 @@
+use cbor_smol::{cbor_deserialize, cbor_serialize_bytes};
+use core::fmt::Debug;
+use cosey::{EcdhEsHkdf256PublicKey, Ed25519PublicKey, P256PublicKey};
+use heapless_bytes::Bytes;
+use quickcheck::{Arbitrary, Gen};
+use serde::{de::DeserializeOwned, Serialize};
+
+#[derive(Clone, Debug)]
+struct Input(Bytes<32>);
+
+impl Arbitrary for Input {
+    fn arbitrary(g: &mut Gen) -> Self {
+        let mut data = vec![0; 32];
+        data.fill_with(|| u8::arbitrary(g));
+        Self(Bytes::from_slice(&data).unwrap())
+    }
+}
+
+fn test_serde<T: Serialize + DeserializeOwned + PartialEq>(data: T) -> bool {
+    let serialized: Bytes<1024> = cbor_serialize_bytes(&data).unwrap();
+    let deserialized: T = cbor_deserialize(&serialized).unwrap();
+    data == deserialized
+}
+
+fn test_de<T: DeserializeOwned + Debug + PartialEq>(s: &str, data: T) {
+    let serialized = hex::decode(s).unwrap();
+    let deserialized: T = cbor_deserialize(&serialized).unwrap();
+    assert_eq!(data, deserialized);
+}
+
+#[test]
+fn de_p256() {
+    let x = Bytes::from_slice(&[0xff; 32]).unwrap();
+    let y = Bytes::from_slice(&[0xff; 32]).unwrap();
+    let key = P256PublicKey { x, y };
+    test_de("a5010203262001215820ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff225820ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", key);
+}
+
+#[test]
+fn de_ecdh() {
+    let x = Bytes::from_slice(&[0xff; 32]).unwrap();
+    let y = Bytes::from_slice(&[0xff; 32]).unwrap();
+    let key = EcdhEsHkdf256PublicKey { x, y };
+    test_de("a501020338182001215820ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff225820ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", key);
+}
+
+#[test]
+fn de_ecdh_order() {
+    // fields in a different order, see https://github.com/solokeys/ctap-types/issues/7
+    let serialized = hex::decode("a42001215820babc05993673d3d9745712333373cc6da964b4814d0cd666ce97c5ffef8befa522582029ebc161c05e3ba0f702a4cf1df30aca224ae3cf7b9478f4a811726976908ef00102").unwrap();
+    cbor_deserialize::<EcdhEsHkdf256PublicKey>(&serialized).unwrap();
+}
+
+#[test]
+fn de_ed25519() {
+    let x = Bytes::from_slice(&[0xff; 32]).unwrap();
+    let key = Ed25519PublicKey { x };
+    test_de(
+        "a4010103272006215820ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        key,
+    );
+}
+
+quickcheck::quickcheck! {
+    #[test]
+    fn serde_p256(x: Input, y: Input) -> bool {
+        test_serde(P256PublicKey {
+            x: x.0,
+            y: y.0,
+        })
+    }
+
+    #[test]
+    fn serde_ecdh(x: Input, y: Input) -> bool {
+        test_serde(EcdhEsHkdf256PublicKey {
+            x: x.0,
+            y: y.0,
+        })
+    }
+
+    #[test]
+    fn serde_ed25519(x: Input) -> bool {
+        test_serde(Ed25519PublicKey {
+            x: x.0,
+        })
+    }
+}
+


### PR DESCRIPTION
Previously, COSE keys could only be deserialized if the map entries were in the correct order. With this patch, the deserialization is made more robust (and also more concise) by introducing a helper struct, RawPublicKey, that is used as an intermediate step during the deserialization. Also, we make the algorithm field optional to conform with the spec.

This is a port from ctap-types:
    https://github.com/solokeys/ctap-types/pull/8