### PR TITLE
Add Deserialize trait to PublicKey

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,9 +140,8 @@ impl Expected for Crv {
     }
 }
 
-// `Deserialize` can't be derived on untagged enum,
-// would need to "sniff" for correct (Kty, Alg, Crv) triple
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(try_from = "RawPublicKey")]
 #[serde(untagged)]
 pub enum PublicKey {
     P256Key(P256PublicKey),
@@ -172,6 +171,44 @@ impl From<Ed25519PublicKey> for PublicKey {
 impl From<TotpPublicKey> for PublicKey {
     fn from(key: TotpPublicKey) -> Self {
         PublicKey::TotpKey(key)
+    }
+}
+
+impl TryFrom<RawPublicKey> for PublicKey {
+    type Error = serde::de::value::Error;
+
+    fn try_from(raw: RawPublicKey) -> Result<Self, Self::Error> {
+        match raw {
+            RawPublicKey {
+                kty: Some(Kty::Ec2),
+                alg: Some(Alg::Es256),
+                crv: Some(Crv::P256),
+                x: Some(x),
+                y: Some(y),
+            } => Ok(PublicKey::P256Key(P256PublicKey { x, y })),
+            RawPublicKey {
+                kty: Some(Kty::Ec2),
+                alg: Some(Alg::EcdhEsHkdf256),
+                crv: Some(Crv::P256),
+                x: Some(x),
+                y: Some(y),
+            } => Ok(PublicKey::EcdhEsHkdf256Key(EcdhEsHkdf256PublicKey { x, y })),
+            RawPublicKey {
+                kty: Some(Kty::Okp),
+                alg: Some(Alg::EdDsa),
+                crv: Some(Crv::Ed25519),
+                x: Some(x),
+                y: None,
+            } => Ok(PublicKey::Ed25519Key(Ed25519PublicKey { x })),
+            RawPublicKey {
+                kty: Some(Kty::Symmetric),
+                alg: Some(Alg::Totp),
+                crv: None,
+                x: None,
+                y: None,
+            } => Ok(PublicKey::TotpKey(TotpPublicKey {})),
+            _ => Err(serde::de::Error::custom("invalid key data")),
+        }
     }
 }
 

--- a/tests/cose.rs
+++ b/tests/cose.rs
@@ -2,7 +2,7 @@ use core::fmt::Debug;
 
 use cbor_smol::{cbor_deserialize, cbor_serialize_bytes};
 use ciborium::Value;
-use cosey::{EcdhEsHkdf256PublicKey, Ed25519PublicKey, P256PublicKey};
+use cosey::{EcdhEsHkdf256PublicKey, Ed25519PublicKey, P256PublicKey, PublicKey};
 use heapless_bytes::Bytes;
 use itertools::Itertools as _;
 use quickcheck::{Arbitrary, Gen};
@@ -150,7 +150,9 @@ fn de_p256() {
     let x = Bytes::from_slice(&[0xff; 32]).unwrap();
     let y = Bytes::from_slice(&[0xff; 32]).unwrap();
     let key = P256PublicKey { x, y };
-    test_de("a5010203262001215820ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff225820ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", key);
+    let data = "a5010203262001215820ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff225820ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+    test_de(data, key.clone());
+    test_de(data, PublicKey::P256Key(key));
 }
 
 #[test]
@@ -158,17 +160,19 @@ fn de_ecdh() {
     let x = Bytes::from_slice(&[0xff; 32]).unwrap();
     let y = Bytes::from_slice(&[0xff; 32]).unwrap();
     let key = EcdhEsHkdf256PublicKey { x, y };
-    test_de("a501020338182001215820ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff225820ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", key);
+    let data = "a501020338182001215820ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff225820ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+    test_de(data, key.clone());
+    test_de(data, PublicKey::EcdhEsHkdf256Key(key));
 }
 
 #[test]
 fn de_ed25519() {
     let x = Bytes::from_slice(&[0xff; 32]).unwrap();
     let key = Ed25519PublicKey { x };
-    test_de(
-        "a4010103272006215820ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-        key,
-    );
+    let data =
+        "a4010103272006215820ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+    test_de(data, key.clone());
+    test_de(data, PublicKey::Ed25519Key(key));
 }
 
 quickcheck::quickcheck! {


### PR DESCRIPTION
Follows @robin-nitrokey's suggestion (https://github.com/trussed-dev/cosey/pull/1#issuecomment-2180911655) to implement the Deserialize trait for PublicKey.

Background and motivation:
* #1
* https://github.com/trussed-dev/ctap-types/pull/15

Upstreaming this change will allow us to publish our first crate for libwebauthn (https://github.com/linux-credentials/libwebauthn/issues/71).

Thanks for your advice so far, and TIA in advance for any feedback!

